### PR TITLE
correct path and submodule names in sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../film_review_scraper/"))
+sys.path.insert(0, os.path.abspath("../../film_review_scraper/"))
 
 project = "film_review_scraper"
 copyright = "2023, Jianghan Chang"

--- a/docs/source/film_review_scraper.data_handling.rst
+++ b/docs/source/film_review_scraper.data_handling.rst
@@ -1,13 +1,13 @@
-film\_review\_scraper.data\_handling package
-============================================
+data\_handling package
+======================
 
 Submodules
 ----------
 
-film\_review\_scraper.data\_handling.file\_handler module
----------------------------------------------------------
+data\_handling.file\_handler module
+-----------------------------------
 
-.. automodule:: film_review_scraper.data_handling.file_handler
+.. automodule:: data_handling.file_handler
    :members:
    :undoc-members:
    :show-inheritance:
@@ -15,7 +15,7 @@ film\_review\_scraper.data\_handling.file\_handler module
 Module contents
 ---------------
 
-.. automodule:: film_review_scraper.data_handling
+.. automodule:: data_handling
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/film_review_scraper.data_processing.rst
+++ b/docs/source/film_review_scraper.data_processing.rst
@@ -4,10 +4,10 @@ film\_review\_scraper.data\_processing package
 Submodules
 ----------
 
-film\_review\_scraper.data\_processing.data\_processor module
--------------------------------------------------------------
+data\_processing.data\_processor module
+---------------------------------------
 
-.. automodule:: film_review_scraper.data_processing.data_processor
+.. automodule:: data_processing.data_processor
    :members:
    :undoc-members:
    :show-inheritance:
@@ -15,7 +15,7 @@ film\_review\_scraper.data\_processing.data\_processor module
 Module contents
 ---------------
 
-.. automodule:: film_review_scraper.data_processing
+.. automodule:: data_processing
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/film_review_scraper.websites.rst
+++ b/docs/source/film_review_scraper.websites.rst
@@ -20,18 +20,18 @@ film\_review\_scraper.websites.douban module
    :undoc-members:
    :show-inheritance:
 
-film\_review\_scraper.websites.imdb module
-------------------------------------------
+websites.imdb module
+--------------------
 
-.. automodule:: film_review_scraper.websites.imdb
+.. automodule:: websites.imdb
    :members:
    :undoc-members:
    :show-inheritance:
 
-film\_review\_scraper.websites.rottentomatoes module
-----------------------------------------------------
+websites.rottentomatoes module
+------------------------------
 
-.. automodule:: film_review_scraper.websites.rottentomatoes
+.. automodule:: websites.rottentomatoes
    :members:
    :undoc-members:
    :show-inheritance:
@@ -39,7 +39,7 @@ film\_review\_scraper.websites.rottentomatoes module
 Module contents
 ---------------
 
-.. automodule:: film_review_scraper.websites
+.. automodule:: websites
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
- path in `conf.py` needed to navigate one more down
- submodules should not have the package name included
- sphinx build still throws a few errors, about `imdb.py`, I will leave it to you to correct those (duplicate documentation)